### PR TITLE
Add Chrome extension for GPT WhatsApp replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # extens-o-chrome
 Estudo para criação de extensões.
+
+## GPT WhatsApp Assistant
+
+Esta pasta `chrome-extension` contém uma extensão para o Google Chrome que integra o WhatsApp Web ao ChatGPT. Ela permite gerar sugestões de respostas de forma automática ou manual.
+
+### Instalação de desenvolvimento
+1. Abra o Chrome e acesse `chrome://extensions`.
+2. Ative o modo de desenvolvedor.
+3. Clique em "Carregar sem compactação" e selecione a pasta `chrome-extension` deste repositório.
+4. Defina sua chave da API da OpenAI no `localStorage` executando no console do DevTools do WhatsApp Web:
+   ```js
+   localStorage.setItem('openai_api_key', 'SUA_CHAVE');
+   ```
+
+### Uso
+- Abra o WhatsApp Web e navegue até a conversa desejada.
+- Clique no ícone da extensão para escolher o modo Automático ou Manual.
+- No modo Manual é possível digitar instruções ou utilizar o botão de voz para falar o que o modelo deve considerar.
+- Pressione "Sugerir resposta" para que a extensão leia as últimas mensagens e insira uma sugestão na caixa de texto do WhatsApp.
+- O botão "Desativar" liga ou desliga rapidamente a extensão.

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,0 +1,10 @@
+let enabled = true;
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'toggle') {
+    enabled = message.enabled;
+    sendResponse({status: 'ok'});
+  } else if (message.type === 'getEnabled') {
+    sendResponse({enabled});
+  }
+});

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,0 +1,48 @@
+async function getLastMessages(count = 10) {
+  const messageNodes = Array.from(document.querySelectorAll('div.copyable-text span.selectable-text'));
+  const texts = messageNodes.slice(-count).map(node => node.innerText);
+  return texts.join('\n');
+}
+
+async function fetchCompletion(prompt) {
+  const apiKey = localStorage.getItem('openai_api_key');
+  if (!apiKey) {
+    console.warn('No OpenAI API key set');
+    return '';
+  }
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-3.5-turbo',
+      messages: [{role: 'user', content: prompt}]
+    })
+  });
+  const data = await res.json();
+  return data.choices?.[0]?.message?.content || '';
+}
+
+async function suggestReply(auto, instruction) {
+  const history = await getLastMessages();
+  let prompt = `Conversation history:\n${history}\n`;
+  if (instruction) {
+    prompt += `Instruction: ${instruction}\n`;
+  }
+  prompt += 'Suggest a response:';
+  const reply = await fetchCompletion(prompt);
+  const box = document.querySelector('div[contenteditable="true"]');
+  if (box) {
+    box.focus();
+    document.execCommand('insertText', false, reply);
+  }
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'suggest') {
+    suggestReply(message.auto, message.instruction).then(() => sendResponse({status: 'ok'}));
+    return true;
+  }
+});

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,0 +1,28 @@
+{
+  "manifest_version": 3,
+  "name": "GPT WhatsApp Assistant",
+  "description": "Suggest responses on WhatsApp Web using ChatGPT.",
+  "version": "0.1",
+  "permissions": [
+    "activeTab",
+    "storage",
+    "scripting"
+  ],
+  "host_permissions": [
+    "https://web.whatsapp.com/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "GPT WhatsApp Assistant"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://web.whatsapp.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    body { min-width: 250px; font-family: Arial, sans-serif; }
+    button { margin-top: 5px; }
+  </style>
+</head>
+<body>
+  <h3>GPT WhatsApp Assistant</h3>
+  <label><input type="radio" name="mode" value="auto" checked> Automático</label><br>
+  <label><input type="radio" name="mode" value="manual"> Manual</label>
+  <textarea id="instruction" placeholder="Instruções" style="width:100%; display:none"></textarea>
+  <button id="voice-btn" style="display:none">Falar instrução</button>
+  <button id="suggest-btn">Sugerir resposta</button>
+  <button id="toggle-btn">Desativar</button>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -1,0 +1,48 @@
+const instructionBox = document.getElementById('instruction');
+const voiceBtn = document.getElementById('voice-btn');
+const suggestBtn = document.getElementById('suggest-btn');
+const toggleBtn = document.getElementById('toggle-btn');
+const modeRadios = document.getElementsByName('mode');
+
+let enabled = true;
+
+function updateUI() {
+  const manual = document.querySelector('input[name="mode"]:checked').value === 'manual';
+  instructionBox.style.display = manual ? 'block' : 'none';
+  voiceBtn.style.display = manual ? 'block' : 'none';
+  toggleBtn.textContent = enabled ? 'Desativar' : 'Ativar';
+}
+
+function getMode() {
+  return document.querySelector('input[name="mode"]:checked').value;
+}
+
+modeRadios.forEach(r => r.addEventListener('change', updateUI));
+
+chrome.runtime.sendMessage({type: 'getEnabled'}, res => {
+  enabled = res.enabled;
+  updateUI();
+});
+
+suggestBtn.addEventListener('click', () => {
+  if (!enabled) return;
+  const mode = getMode();
+  const instruction = instructionBox.value;
+  chrome.tabs.query({active: true, currentWindow: true}, tabs => {
+    chrome.tabs.sendMessage(tabs[0].id, {type: 'suggest', auto: mode === 'auto', instruction});
+  });
+});
+
+toggleBtn.addEventListener('click', () => {
+  enabled = !enabled;
+  chrome.runtime.sendMessage({type: 'toggle', enabled}, () => updateUI());
+});
+
+voiceBtn.addEventListener('click', () => {
+  const recognition = new (window.SpeechRecognition || window.webkitSpeechRecognition)();
+  recognition.lang = 'pt-BR';
+  recognition.onresult = event => {
+    instructionBox.value = event.results[0][0].transcript;
+  };
+  recognition.start();
+});


### PR DESCRIPTION
## Summary
- create `chrome-extension` folder with manifest and scripts for ChatGPT integration
- implement popup UI for automatic/manual suggestion modes and voice instructions
- add content script to read messages and insert replies on WhatsApp Web
- document installation and usage in README

## Testing
- `git status --short`
- `git show -1 --stat`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68482d1ba3e8832d821a7fe9b3289f24